### PR TITLE
nsqd: seperate broadcast ports

### DIFF
--- a/apps/nsqd/options.go
+++ b/apps/nsqd/options.go
@@ -114,6 +114,8 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	authHTTPAddresses := app.StringArray{}
 	flagSet.Var(&authHTTPAddresses, "auth-http-address", "<addr>:<port> to query auth server (may be given multiple times)")
 	flagSet.String("broadcast-address", opts.BroadcastAddress, "address that will be registered with lookupd (defaults to the OS hostname)")
+	flagSet.Int("broadcast-tcp-port", opts.BroadcastTCPPort, "TCP port that will be registered with lookupd (defaults to 4150)")
+	flagSet.Int("broadcast-http-port", opts.BroadcastHTTPPort, "HTTP port that will be registered with lookupd (defaults to 4151)")
 	lookupdTCPAddrs := app.StringArray{}
 	flagSet.Var(&lookupdTCPAddrs, "lookupd-tcp-address", "lookupd TCP address (may be given multiple times)")
 	flagSet.Duration("http-client-connect-timeout", opts.HTTPClientConnectTimeout, "timeout for HTTP connect")

--- a/nsqd/lookup.go
+++ b/nsqd/lookup.go
@@ -16,8 +16,8 @@ func connectCallback(n *NSQD, hostname string) func(*lookupPeer) {
 	return func(lp *lookupPeer) {
 		ci := make(map[string]interface{})
 		ci["version"] = version.Binary
-		ci["tcp_port"] = n.RealTCPAddr().Port
-		ci["http_port"] = n.RealHTTPAddr().Port
+		ci["tcp_port"] = n.getOpts().BroadcastTCPPort
+		ci["http_port"] = n.getOpts().BroadcastHTTPPort
 		ci["hostname"] = hostname
 		ci["broadcast_address"] = n.getOpts().BroadcastAddress
 

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -23,6 +23,8 @@ type Options struct {
 	HTTPAddress              string        `flag:"http-address"`
 	HTTPSAddress             string        `flag:"https-address"`
 	BroadcastAddress         string        `flag:"broadcast-address"`
+	BroadcastTCPPort         int           `flag:"broadcast-tcp-port"`
+	BroadcastHTTPPort        int           `flag:"broadcast-http-port"`
 	NSQLookupdTCPAddresses   []string      `flag:"lookupd-tcp-address" cfg:"nsqlookupd_tcp_addresses"`
 	AuthHTTPAddresses        []string      `flag:"auth-http-address" cfg:"auth_http_addresses"`
 	HTTPClientConnectTimeout time.Duration `flag:"http-client-connect-timeout" cfg:"http_client_connect_timeout"`
@@ -98,10 +100,12 @@ func NewOptions() *Options {
 		LogPrefix: "[nsqd] ",
 		LogLevel:  lg.INFO,
 
-		TCPAddress:       "0.0.0.0:4150",
-		HTTPAddress:      "0.0.0.0:4151",
-		HTTPSAddress:     "0.0.0.0:4152",
-		BroadcastAddress: hostname,
+		TCPAddress:         "0.0.0.0:4150",
+		HTTPAddress:        "0.0.0.0:4151",
+		HTTPSAddress:       "0.0.0.0:4152",
+		BroadcastAddress:   hostname,
+		BroadcastTCPPort:   4150,
+		BroadcastHTTPPort:  4151,
 
 		NSQLookupdTCPAddresses: make([]string, 0),
 		AuthHTTPAddresses:      make([]string, 0),


### PR DESCRIPTION
# Description

When using nsqd within containerised instances, we would require not only a different broadcast address but also different ports to which consumers must contact in order to reach the nsqd.

# Changes
- adds flags to accept `broadcast-tcp-address` and `broadcast-http-address`
- registers nsqd with lookupd using `broadcast-tcp-address` and `broadcast-http-address` instead of the bound ports